### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/biome-config/package.json
+++ b/packages/biome-config/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@red-explosion/biome-config",
   "version": "0.3.0",
+  "bugs": {
+    "url": "https://github.com/red-explosion/common-js/issues"
+  },
   "description": "Red Explosion's Biome config.",
   "keywords": [
     "red-explosion",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/biome-config/package.json`.